### PR TITLE
Session: Decouple writing plaintext from flushing ciphertext

### DIFF
--- a/host/src/session.rs
+++ b/host/src/session.rs
@@ -4,6 +4,7 @@
 
 //! High-level Sprockets session API, akin to a TLS session.
 
+mod aead_write_buf;
 mod decrypting_buf_reader;
 mod encrypting_buf_writer;
 
@@ -79,13 +80,10 @@ pub struct Session<Chan> {
     reader: DecryptingBufReader,
 }
 
-// Buffer size we use for reading/reading to the underlying channel.
+// Buffer size we use for reading/writing encrypted frames to the underlying channel.
 //
-// NOTE: This implicitly sets the maximum chunk size for our encrypted chunks
-// (to `BUFFER_SIZE - 4 - TAG_SIZE`, accounting for the length prefix and auth
-// tag suffix applied to each chunk). Both the reader and writer we create must
-// use the same `BUFFER_SIZE` to avoid runtime mismatches (specifically, the
-// reader will reject chunks larger than its buffer size).
+// NOTE: The actual size of the buffer is the size of the frame which includes a
+// 4 byte size header and an AEAD tag trailer of `TAG_SIZE`.
 const BUFFER_SIZE: usize = 8192;
 
 impl<Chan> Session<Chan>
@@ -163,17 +161,12 @@ where
 
 // Helper function to avoid repeating this closure in each of the `AsyncWrite`
 // methods below.
+//
+// Encryption errors are opaque to avoid leaking info so we return `()`.
 fn encrypt_via_session(
     session: &mut RawSession,
-) -> impl FnOnce(&mut [u8]) -> io::Result<Tag> + '_ {
-    |buf| {
-        session.encrypt_in_place_detached(buf).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("sprockets encryption failed: {err:?}"),
-            )
-        })
-    }
+) -> impl FnOnce(&mut [u8]) -> Result<Tag, ()> + '_ {
+    |buf| session.encrypt_in_place_detached(buf).map_err(|_| ())
 }
 
 impl<Chan: AsyncWrite> AsyncWrite for Session<Chan> {
@@ -222,12 +215,14 @@ impl<Chan: AsyncRead> AsyncRead for Session<Chan> {
     ) -> Poll<io::Result<()>> {
         let me = self.project();
         me.reader.poll_read(me.channel, cx, buf, |buf, tag| {
-            me.session.decrypt_in_place_detached(buf, tag).map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("sprockets decryption failed: {err:?}"),
-                )
-            })
+            me.session
+                .decrypt_in_place_detached(buf, tag)
+                .map_err(|err| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("sprockets decryption failed: {err:?}"),
+                    )
+                })
         })
     }
 }
@@ -438,14 +433,14 @@ mod tests {
         let client_fut = Session::new_client(
             client_stream,
             manufacturing_public_key,
-            &client_handle,
+            client_handle.clone(),
             client_certs,
             Duration::from_secs(10),
         );
         let server_fut = Session::new_server(
             server_stream,
             manufacturing_public_key,
-            &server_handle,
+            server_handle.clone(),
             server_certs,
             Duration::from_secs(10),
         );

--- a/host/src/session/aead_write_buf.rs
+++ b/host/src/session/aead_write_buf.rs
@@ -1,0 +1,147 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Wrappers around a buffer for storing plaintext and ciphertext data for use
+//! with AEAD algorithms.
+//!
+//! The buffer reserves space at the beginning for a 4-byte length header, and
+//! enough data at the end to store an AEAD authentication tag. This allows the
+//! 4 byte framed encrypted data + tag to be sent with one call to the underlying IO
+//! system.
+//!
+//! Plaintext data can be written into the buffer until it is full, at which
+//! point the data can be encrypted in place and extended with an authentication
+//! tag. Once encrypted, the size header is filled in, and the buffer is
+//! "sealed" as an `AeadCiphertextBuf`.
+
+// The location where plaintext/ciphertext start inside `AeadPlaintextBuf` and
+// `AeadCiphertextBuf`.
+const DATA_START: usize = 4;
+use super::TAG_SIZE;
+use sprockets_session::Tag;
+
+/// An extensible buffer storing plaintext data for use with an AEAD algorithm
+pub struct AeadPlaintextBuf {
+    // The entire buffer with a 4 byte size header and TAG_SIZE data at the end.
+    buf: Box<[u8]>,
+
+    // The amount of currently written user data to the buffer. This is the size
+    // of the unencrypted and encrypted data not including the authentication tag.
+    written: usize,
+}
+
+impl AeadPlaintextBuf {
+    /// The total capacity of the underlying buffer is:
+    /// 4 + data_cap + TAG_SIZE
+    pub fn with_capacity(data_cap: usize) -> Self {
+        // Ensure the max chunk size won't overflow our u32 length prefix.
+        assert!(data_cap + TAG_SIZE <= u32::MAX as usize);
+
+        AeadPlaintextBuf {
+            buf: vec![0; DATA_START + data_cap + TAG_SIZE].into_boxed_slice(),
+            written: 0,
+        }
+    }
+
+    // The capacity of the plaintext buffer
+    //
+    // This does not include the 4 byte size header or TAG_SIZE
+    pub fn capacity(&self) -> usize {
+        self.buf.len() - DATA_START - TAG_SIZE
+    }
+
+    // The amount of room left in the user data buffer
+    pub fn remaining(&self) -> usize {
+        self.capacity() - self.written
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.remaining() == 0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.written == 0
+    }
+
+    // Copy as much data as we can from `buf` into `self.buf`.
+    //
+    // Return the number of bytes copied.
+    pub fn extend(&mut self, buf: &[u8]) -> usize {
+        let n = usize::min(self.remaining(), buf.len());
+        let start = DATA_START + self.written;
+        self.buf[start..start + n].copy_from_slice(&buf[..n]);
+        self.written += n;
+        n
+    }
+
+    // Encrypt all plaintext data in the buffer, append the authentication tag,
+    // and write the size header.
+    //
+    // Return the ciphertext on success and `self` if encryption fails.
+    pub fn encrypt<F>(mut self, encrypt: F) -> Result<AeadCiphertextBuf, Self>
+    where
+        F: FnOnce(&mut [u8]) -> Result<Tag, ()>,
+    {
+        // Need a match to appease the borrow checker
+        let tag = match encrypt(self.plaintext_mut_slice()) {
+            Ok(tag) => tag,
+            Err(()) => return Err(self),
+        };
+        self.tag_mut_slice().copy_from_slice(&tag);
+        // This is guaranteed to fit in a u32 from the asserted invariant in
+        // `with_capacity`.
+        let len = u32::try_from(self.written + TAG_SIZE).unwrap();
+        self.buf[..DATA_START].copy_from_slice(&len.to_be_bytes());
+        Ok(AeadCiphertextBuf {
+            buf: self.buf,
+            written: self.written,
+        })
+    }
+
+    // Return the a mutable slice where the tag should be written
+    fn tag_mut_slice(&mut self) -> &mut [u8] {
+        let start = DATA_START + self.written;
+        let end = start + TAG_SIZE;
+        &mut self.buf[start..end]
+    }
+
+    // Return the mutable slice of the written plaintext
+    fn plaintext_mut_slice(&mut self) -> &mut [u8] {
+        let end = DATA_START + self.written;
+        &mut self.buf[DATA_START..end]
+    }
+}
+
+// A "sealed" buffer containing ciphertext and AEAD authentication tag, prefixed
+// with the length of both, and possibly unused free space at the end.
+//
+// The filled part of the buffer can be treated as an application level `frame`
+// for an encrypted protocol.
+pub struct AeadCiphertextBuf {
+    buf: Box<[u8]>,
+
+    // The amount of ciphertext written into buf
+    written: usize,
+}
+
+impl AeadCiphertextBuf {
+    // Return the entire frame as a slice
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..self.len()]
+    }
+
+    // Return the length of the frame
+    pub fn len(&self) -> usize {
+        DATA_START + self.written + TAG_SIZE
+    }
+}
+
+impl From<AeadCiphertextBuf> for AeadPlaintextBuf {
+    fn from(buf: AeadCiphertextBuf) -> Self {
+        AeadPlaintextBuf {
+            buf: buf.buf,
+            written: 0,
+        }
+    }
+}

--- a/host/src/session/encrypting_buf_writer.rs
+++ b/host/src/session/encrypting_buf_writer.rs
@@ -14,35 +14,35 @@
 //! and then attempts to flush that encrypted chunk into the underlying writer.
 //! Further writes to the buffer will block until that flush completes.
 
-use super::TAG_SIZE;
+use super::aead_write_buf::{AeadCiphertextBuf, AeadPlaintextBuf};
+use derive_more::From;
 use futures::ready;
 use sprockets_session::Tag;
 use std::io;
-use std::mem;
-use std::ops::Range;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 use tokio::io::AsyncWrite;
 
-const LENGTH_PREFIX_LEN: usize = mem::size_of::<u32>();
+#[derive(From)]
+enum AeadWriteBuf {
+    Plaintext(AeadPlaintextBuf),
+    Ciphertext {
+        ciphertext: AeadCiphertextBuf,
+        // The amount of data flushed so far
+        flushed: usize,
+    },
+}
 
 pub(super) struct EncryptingBufWriter {
-    buf: Box<[u8]>,
-    copy_pos: usize,
-    flush: Option<Range<usize>>,
+    // Need an option to allow moving from one variant to another
+    buf: Option<AeadWriteBuf>,
 }
 
 impl EncryptingBufWriter {
     pub(super) fn with_capacity(cap: usize) -> Self {
-        // Ensure we have room for at least one byte of data.
-        assert!(cap > LENGTH_PREFIX_LEN + TAG_SIZE);
-        // Ensure the max chunk size won't overflow our u32 length prefix.
-        assert!(cap + TAG_SIZE <= u32::MAX as usize);
         Self {
-            buf: vec![0; cap].into_boxed_slice(),
-            copy_pos: LENGTH_PREFIX_LEN,
-            flush: None,
+            buf: Some(AeadPlaintextBuf::with_capacity(cap).into()),
         }
     }
 
@@ -55,130 +55,169 @@ impl EncryptingBufWriter {
     ) -> Poll<io::Result<usize>>
     where
         T: AsyncWrite,
-        F: FnOnce(&mut [u8]) -> io::Result<Tag>,
+        F: FnOnce(&mut [u8]) -> Result<Tag, ()>,
     {
-        let copy_end = self.buf.len() - TAG_SIZE;
+        // We guarantee that buf is always `Some`. We reset it after the match
+        // if flushing is required. Otherwise, we are appending to the existing
+        // plaintext, so reset it without any further function calls.
+        let (new_buf, ret) = match self.buf.take().unwrap() {
+            AeadWriteBuf::Plaintext(mut plaintext) => {
+                if plaintext.is_full() {
+                    encrypt_and_flush(inner, cx, plaintext, encrypt)
+                } else {
+                    let n = plaintext.extend(buf);
+                    self.buf = Some(plaintext.into());
+                    return Poll::Ready(Ok(n));
+                }
+            }
+            AeadWriteBuf::Ciphertext {
+                ciphertext,
+                flushed,
+            } => flush(inner, cx, ciphertext, flushed),
+        };
 
-        // Flush, if necessary.
-        if self.flush.is_none() && self.copy_pos == copy_end {
-            // We're not currently flushing, but our buffer is full; we need to
-            // encrypt and then flush.
-            self.flush = Some(self.encrypt_current_buffer(encrypt)?);
-        }
-        ready!(self.flush_to_inner_if_needed(inner, cx))?;
+        self.buf = Some(new_buf);
+        ready!(ret)?;
 
-        // Carve out our remaining available space as a subslice.
-        let available = &mut self.buf[self.copy_pos..copy_end];
-
-        // If we return without blocking from `flush_to_inner_if_needed`, two
-        // things must be true: We have no encrypted data waiting to be written,
-        // and we have room to store at least one more byte. Sanity check both.
-        assert!(self.flush.is_none());
-        assert!(!available.is_empty());
-
-        // Copy as much data as we can from `buf`.
-        let n = usize::min(available.len(), buf.len());
-        available[..n].copy_from_slice(&buf[..n]);
-        self.copy_pos += n;
-
+        // If we reached this point we have flushed a a complete encrypted
+        // frame and have an empty plaintext buffer in `self.buf`. We write
+        // some data into the plaintext buffer and fulfill the expectation of
+        // the caller that if there is no error, they will get back
+        // `Poll::Pending` or `Poll::Ready(Ok(n))`. In this case they will get
+        // back `Poll::Ready` because at least some data will be written into
+        // buf.
+        //
+        // However, as we allow the caller to pass an empty slice in `buf`, they
+        // may get back `Poll::Ready(Ok(0))` which does not indicate an error.
+        let n = self.get_plaintext_mut().extend(buf);
         Poll::Ready(Ok(n))
     }
 
     pub(super) fn poll_flush<T, F>(
         &mut self,
-        mut inner: Pin<&mut T>,
+        inner: Pin<&mut T>,
         cx: &mut Context<'_>,
         encrypt: F,
     ) -> Poll<io::Result<()>>
     where
         T: AsyncWrite,
-        F: FnOnce(&mut [u8]) -> io::Result<Tag>,
+        F: FnOnce(&mut [u8]) -> Result<Tag, ()>,
     {
-        // Are we already flushing?
-        ready!(self.flush_to_inner_if_needed(inner.as_mut(), cx))?;
-
-        // Do we have unencrypted, unsent data?
-        if self.copy_pos > LENGTH_PREFIX_LEN {
-            self.flush = Some(self.encrypt_current_buffer(encrypt)?);
-            ready!(self.flush_to_inner_if_needed(inner, cx))?;
-        }
-
-        Poll::Ready(Ok(()))
-    }
-
-    fn flush_to_inner_if_needed<T>(
-        &mut self,
-        mut inner: Pin<&mut T>,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>>
-    where
-        T: AsyncWrite,
-    {
-        // Do we need to flush?
-        let flush = match self.flush.as_mut() {
-            Some(flush) => flush,
-            None => return Poll::Ready(Ok(())),
+        // We guarantee that buf is always `Some`. We reset it after the match.
+        let (new_buf, ret) = match self.buf.take().unwrap() {
+            AeadWriteBuf::Plaintext(plaintext) => {
+                if plaintext.is_empty() {
+                    // Nothing to flush
+                    (plaintext.into(), Poll::Ready(Ok(())))
+                } else {
+                    encrypt_and_flush(inner, cx, plaintext, encrypt)
+                }
+            }
+            AeadWriteBuf::Ciphertext {
+                ciphertext,
+                flushed,
+            } => flush(inner, cx, ciphertext, flushed),
         };
 
-        while flush.start < flush.end {
-            // Extract data remaining to flush.
-            let buf = &self.buf[flush.clone()];
-            let n = ready!(inner.as_mut().poll_write(cx, buf))?;
+        self.buf = Some(new_buf);
+        ret
+    }
 
-            flush.start += n;
+    fn get_plaintext_mut(&mut self) -> &mut AeadPlaintextBuf {
+        if let AeadWriteBuf::Plaintext(plaintext) = self.buf.as_mut().unwrap() {
+            plaintext
+        } else {
+            panic!("AeadWriteBuf contains ciphertext, not plaintext")
         }
+    }
+}
 
-        // Flushing complete; reset.
-        self.flush = None;
-        self.copy_pos = LENGTH_PREFIX_LEN;
+fn encrypt_and_flush<T, F>(
+    inner: Pin<&mut T>,
+    cx: &mut Context<'_>,
+    plaintext: AeadPlaintextBuf,
+    encrypt: F,
+) -> (AeadWriteBuf, Poll<io::Result<()>>)
+where
+    T: AsyncWrite,
+    F: FnOnce(&mut [u8]) -> Result<Tag, ()>,
+{
+    match plaintext.encrypt(encrypt) {
+        Ok(ciphertext) => flush(inner, cx, ciphertext, 0),
+        Err(plaintext) => (
+            plaintext.into(),
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::Other,
+                "encryption failed",
+            ))),
+        ),
+    }
+}
 
-        Poll::Ready(Ok(()))
+fn flush<T>(
+    mut inner: Pin<&mut T>,
+    cx: &mut Context<'_>,
+    ciphertext: AeadCiphertextBuf,
+    mut flushed: usize,
+) -> (AeadWriteBuf, Poll<io::Result<()>>)
+where
+    T: AsyncWrite,
+{
+    let mut ret = Poll::Ready(Ok(()));
+
+    // Flush as much of the ciphertext frame as we can.
+    while flushed != ciphertext.len() {
+        let buf = &ciphertext.as_slice()[flushed..];
+        match inner.as_mut().poll_write(cx, buf) {
+            Poll::Pending => {
+                ret = Poll::Pending;
+                break;
+            }
+            Poll::Ready(Ok(0)) => {
+                ret = Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write ciphertext",
+                )));
+                break;
+            }
+            Poll::Ready(Ok(n)) => {
+                flushed += n;
+            }
+            Poll::Ready(Err(err)) => {
+                ret = Poll::Ready(Err(err));
+                break;
+            }
+        }
     }
 
-    fn encrypt_current_buffer<F>(
-        &mut self,
-        encrypt: F,
-    ) -> io::Result<Range<usize>>
-    where
-        F: FnOnce(&mut [u8]) -> io::Result<Tag>,
-    {
-        // We should only be called if we have a nonzero amount of data to
-        // encrypt and we're not currently flushing.
-        assert!(self.copy_pos > LENGTH_PREFIX_LEN);
-        assert!(self.flush.is_none());
+    // Are we done flushing?
+    let new_buf = if flushed == ciphertext.len() {
+        // Reset the buffer to allow writing plaintext data again
+        AeadPlaintextBuf::from(ciphertext).into()
+    } else {
+        AeadWriteBuf::Ciphertext {
+            ciphertext,
+            flushed,
+        }
+    };
 
-        // `poll_write` should always leave room for the auth tag.
-        assert!(self.buf.len() - self.copy_pos >= TAG_SIZE);
-
-        // Encrypt this chunk.
-        let chunk = &mut self.buf[LENGTH_PREFIX_LEN..self.copy_pos];
-        let tag = encrypt(chunk)?;
-
-        // Append the auth tag into our buffer.
-        assert_eq!(tag.len(), TAG_SIZE);
-        self.buf[self.copy_pos..self.copy_pos + TAG_SIZE].copy_from_slice(&tag);
-
-        // Fill in the length prefix. This is guaranteed to fit in `u32` via the
-        // assertions we performed in `with_capacity()`.
-        let len = (self.copy_pos - LENGTH_PREFIX_LEN + TAG_SIZE) as u32;
-        self.buf[..LENGTH_PREFIX_LEN].copy_from_slice(&len.to_be_bytes());
-
-        // Note the subset of the buffer we need to flush.
-        Ok(0..self.copy_pos + TAG_SIZE)
-    }
+    (new_buf, ret)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use pin_project::pin_project;
+    use std::mem;
     use std::time::Duration;
     use tokio::io::AsyncReadExt;
     use tokio::io::AsyncWriteExt;
 
+    const LENGTH_PREFIX_LEN: usize = mem::size_of::<u32>();
     const DUMMY_TAG: &[u8] = b"16 byte test tag";
+    const TAG_SIZE: usize = DUMMY_TAG.len();
 
-    fn dummy_encrypt(msg: &mut [u8]) -> io::Result<Tag> {
+    fn dummy_encrypt(msg: &mut [u8]) -> Result<Tag, ()> {
         for b in msg {
             *b ^= 1;
         }
@@ -189,14 +228,14 @@ mod tests {
     struct TestWriter<T> {
         #[pin]
         inner: T,
-        encrypt: fn(&mut [u8]) -> io::Result<Tag>,
+        encrypt: fn(&mut [u8]) -> Result<Tag, ()>,
         buf: EncryptingBufWriter,
     }
 
     impl<T> TestWriter<T> {
         fn new(
             inner: T,
-            encrypt: fn(&mut [u8]) -> io::Result<Tag>,
+            encrypt: fn(&mut [u8]) -> Result<Tag, ()>,
             capacity: usize,
         ) -> Self {
             Self {
@@ -240,11 +279,7 @@ mod tests {
         let (tx, mut rx) = tokio::io::duplex(128);
 
         // Allocate a writer with space for 8 bytes + overhead.
-        let mut tx = TestWriter::new(
-            tx,
-            dummy_encrypt,
-            8 + LENGTH_PREFIX_LEN + TAG_SIZE,
-        );
+        let mut tx = TestWriter::new(tx, dummy_encrypt, 8);
 
         // Writing 6 bytes should not flush to the underlying buffer.
         tx.write_all(b"012345").await.unwrap();
@@ -330,11 +365,7 @@ mod tests {
         let (tx, mut rx) = tokio::io::duplex(128);
 
         // Allocate a writer with space for 8 bytes + overhead.
-        let mut tx = TestWriter::new(
-            tx,
-            dummy_encrypt,
-            8 + LENGTH_PREFIX_LEN + TAG_SIZE,
-        );
+        let mut tx = TestWriter::new(tx, dummy_encrypt, 8);
 
         // We can write 0-length buffers into `tx`, but flushing after any
         // number of them should not result in any data being sent.
@@ -359,11 +390,7 @@ mod tests {
         let (tx, _rx) = tokio::io::duplex(128);
 
         // Use an always-failing encryption closure.
-        let mut tx = TestWriter::new(
-            tx,
-            |_| Err(io::Error::new(io::ErrorKind::Other, "boom")),
-            128,
-        );
+        let mut tx = TestWriter::new(tx, |_| Err(()), 128);
 
         // Writing won't fail...
         tx.write_all(b"hello").await.unwrap();
@@ -372,7 +399,7 @@ mod tests {
         let err = tx.flush().await.unwrap_err();
 
         assert_eq!(err.kind(), io::ErrorKind::Other);
-        assert_eq!(err.to_string(), "boom");
+        assert_eq!(err.to_string(), "encryption failed");
     }
 
     #[tokio::test]
@@ -381,11 +408,7 @@ mod tests {
 
         // Use an always-failing encryption closure with a buffer sized for a
         // length=5 chunk plus overhead.
-        let mut tx = TestWriter::new(
-            tx,
-            |_| Err(io::Error::new(io::ErrorKind::Other, "boom")),
-            5 + LENGTH_PREFIX_LEN + TAG_SIZE,
-        );
+        let mut tx = TestWriter::new(tx, |_| Err(()), 5);
 
         // Write 5 bytes; this should fill the buffer.
         tx.write_all(b"01234").await.unwrap();
@@ -393,7 +416,7 @@ mod tests {
         // Flushing should fail when it tries to encrypt.
         let err = tx.flush().await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Other);
-        assert_eq!(err.to_string(), "boom");
+        assert_eq!(err.to_string(), "encryption failed");
 
         // Swap out our encryption function for one that works.
         tx.encrypt = dummy_encrypt;


### PR DESCRIPTION
This commit builds upon #14, but restructures the `EncryptingBufWriter` so that
operations on plaintext and ciphertext are more clearly delineated. Plaintext is
written into the buffer, and then it is encrypted and flushed when either the
plaintext buffer is full or the caller explicitly requests a flush. Once the
ciphertext is being flushed, data cannot be written to the buffer, until it is
completely flushed.

The behavior described above is identical to the implementation in #14, but the
implementation is more explicit. Rather than relying on a `flush` range to
determine if we have ciphertext, we put the actual buffer into its own 2-state
typestate. The buffer is writable when it is plaintext. Once encrypted, it
becomes an immutable ciphertext frame that includes a 4-byte size header and
trailing authentication tag. Calls to `poll_write` or `poll_flush` will flush
any ciphertext until complete. When the ciphertext has been completely flushed,
the typestate will transition back to an empty plaintext buffer. This ensures at
compile time that the proper operations are taken and makes the code somewhat
easier to read.

As part of this change, `EncryptingBufWriter` now contains an enum,
`AeadWriteBuf`, that contains the 2 typestates of the underlying buffer. To
maintain the compile time typestate guarantees, `self` is taken by
value when `AeadPlaintextBuf::encrypt` is called, so that the user will not
accidentally append plaintext to ciphertext. Unfortunately, due to rust's
semantics, this requires storing `AeadWriteBuf` inside an `Option` so that we
can extract it from `EncryptingBufWriter` and replace it with the new typestate
value. Because of this, we must ensure that we always reset the value of
`self.buf` in `EncryptingBufWriter` to `Some` before we return from an API call.
This prohibits early return in some cases and forces match statements. In short,
we trade off some ergonomics for compile time safety in terms of the typestate
pattern and runtime asserts if we make a major error and don't reset the value
of `self.buf`. We hope this also adds clarity to the code due to its explicitness.

As part of this commit, two other subtle changes were made:

1. When creating a buffer, the user gives the data capacity and tag length. They
no longer explicitly calculate the size of the buffer and include the frame size
header and tag length in their capacity. The intention is to treat the buffer
when in plaintext mode as something where a user writes up their data capacity,
and only treat the header and tag as valid once the ciphertext is
created/sealed.
2. The encryption function no longer returns an `io::Error`. It returns `()` to
clearly indicate that encryption errors should be opaque to prevent side channel
attacks. While the error returned from our current encryption library is opaque,
this prevents subtle errors in the case we change libraries in the future that
don't provide this guarantee.