### PR TITLE
Add manufacturing public key to `GetCertificates` response

### DIFF
--- a/common/src/certificates.rs
+++ b/common/src/certificates.rs
@@ -35,6 +35,9 @@ pub struct Ed25519Certificates {
     // should also probably sign it.
     pub serial_number: SerialNumber,
 
+    /// The public portion of the Manufacturing key
+    pub manufacturing_public_key: Ed25519PublicKey,
+
     /// The certificate by the Manufacturing key for the DeviceId key
     pub device_id: Ed25519Certificate,
 
@@ -92,6 +95,9 @@ impl Ed25519Certificates {
 
         Ed25519Certificates {
             serial_number,
+            manufacturing_public_key: Ed25519PublicKey(
+                manufacturing_keypair.public.to_bytes(),
+            ),
             device_id,
             measurement,
             dhe,

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -12,7 +12,7 @@ ring = "0.16.20"
 hubpack = { rev = "df08cc3a6e1f97381cd0472ae348e310f0119e25", git = "https://github.com/cbiffle/hubpack.git", optional = true }
 derive_more = "0.99.17"
 serde = { version = "1.0.136", features = ["derive"]  }
-serialport = { version = "4.0.1", optional = true }
+serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "illumos-support", optional = true }
 clap = { version = "3.1", features = ["derive"] }
 corncobs = { version = "0.1.1", features = ["std"], optional = true }
 thiserror = "1.0.30"

--- a/host/src/bin/sprockets-cli.rs
+++ b/host/src/bin/sprockets-cli.rs
@@ -36,7 +36,8 @@ fn main() -> anyhow::Result<()> {
 #[cfg(feature = "uart")]
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    let mut uart = sprockets_host::Uart::attach(&args.path, args.baud_rate)?;
+    let mut uart =
+        sprockets_host::uart::Uart::attach(&args.path, args.baud_rate)?;
 
     let op = match args.op {
         Op::GetCertificates => RotOpV1::GetCertificates,

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -6,7 +6,7 @@ mod rot_manager;
 mod session;
 
 #[cfg(feature = "uart")]
-mod uart;
+pub mod uart;
 
 pub use sprockets_common::certificates::Ed25519Certificate;
 pub use sprockets_common::certificates::Ed25519Certificates;
@@ -24,6 +24,3 @@ pub use self::rot_manager::RotTransport;
 pub use self::session::Session;
 pub use self::session::SessionError;
 pub use self::session::SessionHandshakeError;
-
-#[cfg(feature = "uart")]
-pub use self::uart::Uart;

--- a/hyper-sprockets/examples/common/mod.rs
+++ b/hyper-sprockets/examples/common/mod.rs
@@ -6,7 +6,6 @@ use slog::Logger;
 use sprockets_common::msgs::RotResponseV1;
 use sprockets_common::random_buf;
 use sprockets_host::Ed25519Certificates;
-use sprockets_host::Ed25519PublicKey;
 use sprockets_host::RotManager;
 use sprockets_host::RotManagerHandle;
 use sprockets_host::RotTransport;
@@ -21,7 +20,6 @@ use thiserror::Error;
 const MANUFACTURING_SEED: [u8; 32] = *b"-sprockets-manufacturing-shared-";
 
 pub(super) struct SimulatedRot {
-    pub(super) manufacturing_public_key: Ed25519PublicKey,
     pub(super) certs: Ed25519Certificates,
     pub(super) handle: RotManagerHandle<TransportError>,
 }
@@ -40,13 +38,7 @@ impl SimulatedRot {
         let (manager, handle) = RotManager::new(1, transport, log);
         thread::spawn(move || manager.run());
 
-        Self {
-            manufacturing_public_key: Ed25519PublicKey(
-                manufacturing_keypair.public.to_bytes(),
-            ),
-            certs,
-            handle,
-        }
+        Self { certs, handle }
     }
 }
 

--- a/hyper-sprockets/examples/hyper-client.rs
+++ b/hyper-sprockets/examples/hyper-client.rs
@@ -33,7 +33,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Wrap a hyper HttpConnector in our sprockets adaptor.
     let connector = SprocketsConnector::new(
         HttpConnector::new(),
-        rot.manufacturing_public_key,
         rot.certs,
         rot.handle,
         Duration::from_secs(1), // simulated RoT never times out

--- a/hyper-sprockets/examples/hyper-server.rs
+++ b/hyper-sprockets/examples/hyper-server.rs
@@ -49,7 +49,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ... wrapped in an adaptor that secures connections via sprockets.
     let acceptor = SprocketsAcceptor::new(
         acceptor,
-        rot.manufacturing_public_key,
         rot.certs,
         rot.handle,
         Duration::from_secs(1), // simulated RoT never times out

--- a/hyper-sprockets/src/server.rs
+++ b/hyper-sprockets/src/server.rs
@@ -5,7 +5,6 @@
 use futures::future::BoxFuture;
 use futures::ready;
 use hyper::server::accept::Accept;
-use sprockets_common::Ed25519PublicKey;
 use sprockets_host::Ed25519Certificates;
 use sprockets_host::RotManagerHandle;
 use sprockets_host::Session;
@@ -121,7 +120,6 @@ where
 
 pub struct SprocketsAcceptor<T, E: Error> {
     listener: T,
-    manufacturing_public_key: Ed25519PublicKey,
     rot_certs: Ed25519Certificates,
     rot_handle: RotManagerHandle<E>,
     rot_timeout: Duration,
@@ -130,14 +128,12 @@ pub struct SprocketsAcceptor<T, E: Error> {
 impl<T, E: Error> SprocketsAcceptor<T, E> {
     pub fn new(
         listener: T,
-        manufacturing_public_key: Ed25519PublicKey,
         rot_certs: Ed25519Certificates,
         rot_handle: RotManagerHandle<E>,
         rot_timeout: Duration,
     ) -> Self {
         Self {
             listener,
-            manufacturing_public_key,
             rot_certs,
             rot_handle,
             rot_timeout,
@@ -163,7 +159,6 @@ where
             Some(Ok(conn)) => {
                 let session = Session::new_server(
                     conn,
-                    me.manufacturing_public_key,
                     me.rot_handle.clone(),
                     me.rot_certs,
                     me.rot_timeout,

--- a/proxy/examples/sprocksy.rs
+++ b/proxy/examples/sprocksy.rs
@@ -11,7 +11,6 @@ use slog::Logger;
 use sprockets_common::msgs::RotResponseV1;
 use sprockets_common::random_buf;
 use sprockets_host::Ed25519Certificates;
-use sprockets_host::Ed25519PublicKey;
 use sprockets_host::RotManager;
 use sprockets_host::RotManagerHandle;
 use sprockets_host::RotTransport;
@@ -71,7 +70,6 @@ async fn main() {
             target_address: args.target_address,
             role: args.role.into(),
         },
-        rot.manufacturing_public_key,
         rot.handle,
         rot.certs,
         Duration::ZERO,
@@ -96,7 +94,6 @@ async fn main() {
 const MANUFACTURING_SEED: [u8; 32] = *b"sprocksy-demo-manufacturing-seed";
 
 struct SimulatedRot {
-    manufacturing_public_key: Ed25519PublicKey,
     certs: Ed25519Certificates,
     handle: RotManagerHandle<TransportError>,
 }
@@ -115,13 +112,7 @@ impl SimulatedRot {
         let (manager, handle) = RotManager::new(1, transport, log);
         thread::spawn(move || manager.run());
 
-        Self {
-            manufacturing_public_key: Ed25519PublicKey(
-                manufacturing_keypair.public.to_bytes(),
-            ),
-            certs,
-            handle,
-        }
+        Self { certs, handle }
     }
 }
 

--- a/session/src/client.rs
+++ b/session/src/client.rs
@@ -73,7 +73,6 @@ enum State {
 
 /// The client side of a secure session handshake
 pub struct ClientHandshake {
-    manufacturing_public_key: Ed25519PublicKey,
     client_certs: Ed25519Certificates,
     transcript: Sha3_256,
     // We don't know the server identity when we're created, but once we get it
@@ -90,7 +89,6 @@ impl ClientHandshake {
     ///
     /// Return the ClientHandshake along with a RecvToken.
     pub fn init(
-        manufacturing_public_key: Ed25519PublicKey,
         client_certs: Ed25519Certificates,
         buf: &mut HandshakeMsgVec,
     ) -> (ClientHandshake, RecvToken) {
@@ -118,7 +116,6 @@ impl ClientHandshake {
         transcript.update(&buf);
 
         let client = ClientHandshake {
-            manufacturing_public_key,
             client_certs,
             transcript,
             server_identity: None,
@@ -431,9 +428,10 @@ impl ClientHandshake {
             self.transcript.update(buf);
 
             // Validate the certificate chains
-            identity
-                .certs
-                .validate(&self.manufacturing_public_key, &DalekVerifier)?;
+            identity.certs.validate(
+                &self.client_certs.manufacturing_public_key,
+                &DalekVerifier,
+            )?;
 
             // Ensure measurements concatenated with the client nonce are
             // properly signed.


### PR DESCRIPTION
The primary change in this PR is to include the manufacturing public key when getting certs from the RoT. This had a nontrivial ripple effect of removing the separate `manufacturing_public_key` field/arg from several other structs / functions.

Other minor changes:

* Point to a fork of `serialport-rs` that includes illumos support
* Add `Uart::set_timeout()` to control the timeout after attaching
* Make the `uart` module public (previously, callers had no way to name the error types it contains)