### PR TITLE
point salty dependencies at oxide mirror

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,12 +9,12 @@ hubpack = "0.1"
 serde = { version = "1.0.136", default-features = false, features = ["derive"]  }
 serde-big-array = { version = "0.4.1" }
 rand = { version = "0.8.5", optional = true }
-salty = { version = "0.2.0", optional = true }
+salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize", optional = true }
 
 [dev-dependencies]
 ed25519 = { version = "1.4.1" }
 ed25519-dalek = { version = "1.0.1", features = ["u64_backend"]}
-salty = { version = "0.2.0" }
+salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize" }
 rand = "0.8.5"
 
 [features]

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -25,7 +25,7 @@ uart = ["serialport", "corncobs", "hubpack"]
 
 [dev-dependencies]
 # Salty is used by the RoT for Ed25519 signatures
-salty = { version = "0.2.0" }
+salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize" }
 sprockets-rot = { path = "../rot" }
 slog-term = "2.9.0"
 slog-async = "2.7.0"

--- a/host/fuzz/Cargo.toml
+++ b/host/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-salty = { version = "0.2.0" }
+salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize" }
 slog = "2.7.0"
 slog-async = "2.7.0"
 slog-term = "2.9.0"

--- a/hyper-sprockets/Cargo.toml
+++ b/hyper-sprockets/Cargo.toml
@@ -19,7 +19,7 @@ client = ["hyper/client"]
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
-salty = { version = "0.2.0" }
+salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize" }
 slog = "2.7.0"
 slog-term = "2.9.0"
 slog-async = "2.7.0"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1.18.1", features = ["io-util", "net"] }
 
 [dev-dependencies]
 clap = "3.1"
-salty = { version = "0.2.0" }
+salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize" }
 slog = "2.7.0"
 slog-term = "2.9.0"
 slog-async = "2.7.0"

--- a/rot/Cargo.toml
+++ b/rot/Cargo.toml
@@ -10,7 +10,7 @@ hubpack = "0.1"
 tinyvec = { version = "1.5.1" }
 derive_more = "0.99.17"
 serde = { version = "1.0.136", default-features = false, features = ["derive"]  }
-salty = { version = "0.2.0" }
+salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize" }
 rand = { version = "0.8.5", optional = true }
 
 [features]

--- a/session/Cargo.toml
+++ b/session/Cargo.toml
@@ -28,5 +28,5 @@ hmac = "0.12.1"
 
 [dev-dependencies]
 # Salty is used by the RoT for Ed25519 signatures
-salty = { version = "0.2.0" }
+salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize" }
 sprockets-rot = { path = "../rot" }


### PR DESCRIPTION
This mirror is the latest salty release (they don't tag releases upstream but I've verified the hash from crates.io) plus a commit adding zeroize support.

This resolves #35.