### PR TITLE
Fix clippy lints currently breaking CI.

### DIFF
--- a/host/src/rot_manager.rs
+++ b/host/src/rot_manager.rs
@@ -32,7 +32,7 @@ pub trait RotTransport {
 }
 
 // An error resulting from communcation with the RotManager
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum RotManagerError<T: Error> {
     #[error("send to RotManager failed. Is the RotManager running?")]
     SendFailed(RotOpV1),

--- a/hyper-sprockets/src/server.rs
+++ b/hyper-sprockets/src/server.rs
@@ -27,6 +27,7 @@ pub struct SprocketsStream<T, E: Error> {
     state: State<T, E>,
 }
 
+#[allow(clippy::large_enum_variant)]
 enum State<T, E: Error> {
     Handshaking(SessionFut<'static, T, E>),
     Streaming(Session<T>),

--- a/rot/src/lib.rs
+++ b/rot/src/lib.rs
@@ -166,7 +166,7 @@ impl RotConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RotSprocketError {
     InvalidSerializedReq,
     DeserializationBufferTooSmall,


### PR DESCRIPTION
Ignoring the 'large-enum_variant' lint in the hyper-sprockets server may be controversial. The alternative is to Box the session but this commit assumes that the current implementation is intentional.