### PR TITLE
Upgrade chacha20poly1305 to version 0.10.

### DIFF
--- a/session/Cargo.toml
+++ b/session/Cargo.toml
@@ -21,7 +21,7 @@ ed25519 = { version = "1.4.1" }
 ed25519-dalek = { version = "1.0.1", features = ["u64_backend"]}
 x25519-dalek = { version = "2.0.0-pre.1" }
 sha3 = "0.10.1"
-chacha20poly1305 = { version = "0.9.0", features = ["heapless"] }
+chacha20poly1305 = { version = "0.10", features = ["heapless"] }
 hkdf = "0.12.3"
 zeroize = "1"
 hmac = "0.12.1"

--- a/session/src/handshake_state.rs
+++ b/session/src/handshake_state.rs
@@ -4,7 +4,7 @@
 
 //! The state needed for handshake encyption by both client and server
 
-use chacha20poly1305::aead::{AeadInPlace, NewAead};
+use chacha20poly1305::aead::{AeadInPlace, KeyInit};
 use chacha20poly1305::{self, ChaCha20Poly1305, Key};
 use hkdf::Hkdf;
 use hmac::{Hmac, Mac};
@@ -212,7 +212,8 @@ impl HandshakeState {
             Role::Client => self.server_finished_key.as_ref(),
             Role::Server => self.client_finished_key.as_ref(),
         };
-        let mut mac = Hmac::<Sha3_256>::new_from_slice(finished_key).unwrap();
+        let mut mac =
+            <Hmac<Sha3_256> as Mac>::new_from_slice(finished_key).unwrap();
         mac.update(transcript_hash);
         mac.verify_slice(finished_mac).map_err(|_| Error::BadMac)
     }
@@ -224,7 +225,8 @@ impl HandshakeState {
             Role::Client => self.client_finished_key.as_ref(),
             Role::Server => self.server_finished_key.as_ref(),
         };
-        let mut mac = Hmac::<Sha3_256>::new_from_slice(finished_key).unwrap();
+        let mut mac =
+            <Hmac<Sha3_256> as Mac>::new_from_slice(finished_key).unwrap();
         mac.update(transcript_hash);
         HmacSha3_256(mac.finalize().into_bytes().into())
     }

--- a/session/src/session.rs
+++ b/session/src/session.rs
@@ -4,7 +4,7 @@
 
 //! Secure Session type
 
-use chacha20poly1305::aead::{AeadInPlace, Buffer, NewAead};
+use chacha20poly1305::aead::{AeadInPlace, Buffer, KeyInit};
 use chacha20poly1305::{self, ChaCha20Poly1305, Key, Tag};
 use hkdf::Hkdf;
 use sha3::Sha3_256;


### PR DESCRIPTION
NewAead trait was replaced by KeyInit. Had to disambiguate a conflict between trait function 'new_from_slice' in KeyInit and Mac.