### PR TITLE
Trivial: cleanup for sprockets-common usage across both RoT and SP

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,7 +12,7 @@ rand = { version = "0.8.5", optional = true }
 salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize", optional = true }
 
 [dev-dependencies]
-ed25519 = { version = "1.4.1" }
+ed25519 = { version = "1.5.2" }
 ed25519-dalek = { version = "1.0.1", features = ["u64_backend"]}
 salty = { git = "https://github.com/oxidecomputer/salty", branch = "v0.2.0-zeroize" }
 rand = "0.8.5"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sprockets-common"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/common/src/certificates.rs
+++ b/common/src/certificates.rs
@@ -4,7 +4,6 @@
 
 use derive_more::From;
 use hubpack::SerializedSize;
-use salty;
 use serde::{Deserialize, Serialize};
 
 pub use crate::{Ed25519PublicKey, Ed25519Signature};
@@ -48,6 +47,7 @@ pub struct Ed25519Certificates {
     pub dhe: Ed25519Certificate,
 }
 
+#[cfg(feature = "salty")]
 impl Ed25519Certificates {
     // TODO: We eventually must get rid of this as we will not have access to
     // the manufacturing secret key.
@@ -287,6 +287,7 @@ pub enum KeyType {
     Dhe,
 }
 
+#[cfg(feature = "salty")]
 #[cfg(test)]
 mod tests {
 

--- a/rot/Cargo.toml
+++ b/rot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sprockets-rot"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/rot/src/lib.rs
+++ b/rot/src/lib.rs
@@ -19,7 +19,6 @@ use sprockets_common::{random_buf, Nonce, Sha3_256Digest};
 use hubpack::{deserialize, serialize};
 
 pub use salty;
-pub use sprockets_common as common;
 
 /// A key management and measurement service run on the RoT
 pub struct RotSprocket {

--- a/session/Cargo.toml
+++ b/session/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.136", default-features = false, features = ["derive"]  
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 ed25519 = { version = "1.4.1" }
 ed25519-dalek = { version = "1.0.1", features = ["u64_backend"]}
-x25519-dalek = { version = "2.0.0-pre.1" }
+x25519-dalek = { version = "2.0.0-rc.2" }
 sha3 = "0.10.1"
 chacha20poly1305 = { version = "0.10", features = ["heapless"] }
 hkdf = "0.12.3"

--- a/session/src/client.rs
+++ b/session/src/client.rs
@@ -92,7 +92,7 @@ impl ClientHandshake {
         client_certs: Ed25519Certificates,
         buf: &mut HandshakeMsgVec,
     ) -> (ClientHandshake, RecvToken) {
-        let secret = EphemeralSecret::new(OsRng);
+        let secret = EphemeralSecret::random_from_rng(OsRng);
         let public_key = PublicKey::from(&secret);
 
         let client_nonce = Nonce::new();

--- a/session/src/server.rs
+++ b/session/src/server.rs
@@ -254,7 +254,7 @@ impl ServerHandshake {
         client_hello: ClientHello,
         buf: &mut HandshakeMsgVec,
     ) -> Result<UserAction, Error> {
-        let secret = EphemeralSecret::new(OsRng);
+        let secret = EphemeralSecret::random_from_rng(OsRng);
         let public_key = PublicKey::from(&secret);
         let server_nonce = Nonce::new();
 


### PR DESCRIPTION
 * Don't actually use salty when the feature is disabled
 * Bump ed25519
 * Don't re-export sprockets-common from sprockets-rot
 * Bump sprockets-common and sprockest-rot to `0.1.1` each
 * Bump x25519-dalek in sprockets-session and remove deprecated usage of `EphemeralSecret::new`