### PR TITLE
Remove `anyhow` from the library API & simplify `load_root_cert`

### DIFF
--- a/tls/Cargo.toml
+++ b/tls/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 clap.workspace = true
-anyhow.workspace = true
 attest-data.workspace = true
 camino.workspace = true
 cfg-if.workspace = true


### PR DESCRIPTION
We lose a lot of context (including the file path) w/ this approach but I'm not sure I've got a better alternative