### PR TITLE
generate the TLS cert chain used in testing in the right order

### DIFF
--- a/tls/src/keys.rs
+++ b/tls/src/keys.rs
@@ -121,12 +121,10 @@ impl CertResolver {
             Certificate::load_pem_chain(&std::fs::read(cert_chain)?)?;
 
         Ok(Arc::new(CertifiedKey::new(
-            // The chain needs to be in reverse order
-            // - Convert all our certs to der
-            // - Convert the DER into the format rustls expects
+            // Convert certs to der and transform into the type expected by
+            // rustls
             pem_chain
                 .into_iter()
-                .rev()
                 .map(|x| x.to_der())
                 .collect::<Result<Vec<Vec<u8>>, _>>()?
                 .into_iter()

--- a/tls/test-keys/config.kdl
+++ b/tls/test-keys/config.kdl
@@ -201,12 +201,11 @@ certificate "test-sprockets-auth-1" {
     }
 }
 
-// TODO: sprockets reverses this cert chain before passing it to rustls
 certificate-list "test-sprockets-auth-1" \
-    "test-signer-a1" \
-    "test-platformid-1" \
+    "test-sprockets-auth-1" \
     "test-deviceid-1" \
-    "test-sprockets-auth-1"
+    "test-platformid-1" \
+    "test-signer-a1"
 
 key-pair "test-alias-1" {
     ed25519
@@ -378,12 +377,11 @@ certificate "test-sprockets-auth-2" {
     }
 }
 
-// TODO: sprockets reverses this cert chain before passing it to rustls
 certificate-list "test-sprockets-auth-2" \
-    "test-signer-a1" \
-    "test-platformid-2" \
+    "test-sprockets-auth-2" \
     "test-deviceid-2" \
-    "test-sprockets-auth-2"
+    "test-platformid-2" \
+    "test-signer-a1"
 
 key-pair "test-alias-2" {
     ed25519


### PR DESCRIPTION
the cert chain is only reversed when using certs from local files so the ipcc cert chain is unaffected