### PR TITLE
Allow passing in a fixed refernence corpus for local measurements

### DIFF
--- a/tls/examples/client.rs
+++ b/tls/examples/client.rs
@@ -73,7 +73,7 @@ async fn main() {
                 priv_key: attest_priv_key,
                 cert_chain: attest_cert_chain,
                 log,
-                fixed_corpus: vec![],
+                test_corpus: vec![],
             },
             ResolveSetting::Local {
                 priv_key: tq_priv_key,

--- a/tls/examples/client.rs
+++ b/tls/examples/client.rs
@@ -73,6 +73,7 @@ async fn main() {
                 priv_key: attest_priv_key,
                 cert_chain: attest_cert_chain,
                 log,
+                fixed_corpus: vec![],
             },
             ResolveSetting::Local {
                 priv_key: tq_priv_key,

--- a/tls/examples/server.rs
+++ b/tls/examples/server.rs
@@ -74,7 +74,7 @@ async fn main() {
                 priv_key: attest_priv_key,
                 cert_chain: attest_cert_chain,
                 log,
-                fixed_corpus: vec![],
+                test_corpus: vec![],
             },
             ResolveSetting::Local {
                 priv_key: tq_priv_key,

--- a/tls/examples/server.rs
+++ b/tls/examples/server.rs
@@ -74,6 +74,7 @@ async fn main() {
                 priv_key: attest_priv_key,
                 cert_chain: attest_cert_chain,
                 log,
+                fixed_corpus: vec![],
             },
             ResolveSetting::Local {
                 priv_key: tq_priv_key,

--- a/tls/src/client.rs
+++ b/tls/src/client.rs
@@ -157,13 +157,6 @@ impl Client {
             }
         };
 
-        // load corims into a set of ReferenceMeasurements
-        let mut corims = Vec::new();
-        for c in corpus {
-            corims.push(Corim::from_file(c)?);
-        }
-        let corpus = ReferenceMeasurements::try_from(corims.as_slice())?;
-
         Client::connect_with_config(c, config.attest, roots, corpus, addr, log)
             .await
     }
@@ -232,7 +225,7 @@ impl Client {
         tls_config: ClientConfig,
         attest_config: AttestConfig,
         roots: Vec<Certificate>,
-        reference_measurements: ReferenceMeasurements,
+        corpus: Vec<Utf8PathBuf>,
         addr: SocketAddrV6,
         log: slog::Logger,
     ) -> Result<Stream<TcpStream>, Error> {
@@ -380,6 +373,18 @@ impl Client {
             &nonce,
         )?;
         info!(log, "Peer attestation verified");
+
+        // load corims into a set of ReferenceMeasurements
+        let mut corims = Vec::new();
+        for c in corpus {
+            corims.push(Corim::from_file(c)?);
+        }
+
+        for c in attest_data.fixed_corpus {
+            corims.push(Corim::from_file(c)?);
+        }
+        let reference_measurements =
+            ReferenceMeasurements::try_from(corims.as_slice())?;
 
         // appraise measurements from server attestation against reference
         // measurements

--- a/tls/src/client.rs
+++ b/tls/src/client.rs
@@ -380,7 +380,7 @@ impl Client {
             corims.push(Corim::from_file(c)?);
         }
 
-        for c in attest_data.fixed_corpus {
+        for c in attest_data.test_corpus {
             corims.push(Corim::from_file(c)?);
         }
         let reference_measurements =

--- a/tls/src/keys.rs
+++ b/tls/src/keys.rs
@@ -373,6 +373,8 @@ pub enum AttestConfig {
         priv_key: Utf8PathBuf,
         cert_chain: Utf8PathBuf,
         log: Utf8PathBuf,
+        #[serde(default)]
+        fixed_corpus: Vec<Utf8PathBuf>,
     },
 }
 
@@ -382,6 +384,7 @@ pub struct AttestArtifacts {
     pub certs: Vec<Certificate>,
     pub log: dice_verifier::Log,
     pub attestation: dice_verifier::Attestation,
+    pub fixed_corpus: Vec<Utf8PathBuf>,
 }
 
 /// This function encapsulates our IPCC usage in a non-async function. This is
@@ -396,18 +399,24 @@ pub fn get_attest_data(
     use dice_verifier::{ipcc::AttestIpcc, Attest, AttestMock};
 
     // create the `Attest` impl prescribed by the config
-    let attest: Box<dyn Attest> = match config {
-        AttestConfig::Ipcc => Box::new(AttestIpcc::new()?),
-        AttestConfig::Local {
-            priv_key,
-            cert_chain,
-            log,
-        } => Box::new(AttestMock::load(cert_chain, log, priv_key)?),
-    };
+    let (attest, fixed_corpus): (Box<dyn Attest>, Vec<Utf8PathBuf>) =
+        match config {
+            AttestConfig::Ipcc => (Box::new(AttestIpcc::new()?), vec![]),
+            AttestConfig::Local {
+                priv_key,
+                cert_chain,
+                log,
+                fixed_corpus,
+            } => (
+                Box::new(AttestMock::load(cert_chain, log, priv_key)?),
+                fixed_corpus.to_vec(),
+            ),
+        };
 
     Ok(AttestArtifacts {
         certs: attest.get_certificates()?,
         log: attest.get_measurement_log()?,
         attestation: attest.attest(nonce)?,
+        fixed_corpus,
     })
 }

--- a/tls/src/keys.rs
+++ b/tls/src/keys.rs
@@ -373,8 +373,10 @@ pub enum AttestConfig {
         priv_key: Utf8PathBuf,
         cert_chain: Utf8PathBuf,
         log: Utf8PathBuf,
+        // Pass in a fixed corpus for test purposes. This is intentionally
+        // only availabe on the `local` configuration!
         #[serde(default)]
-        fixed_corpus: Vec<Utf8PathBuf>,
+        test_corpus: Vec<Utf8PathBuf>,
     },
 }
 
@@ -384,7 +386,7 @@ pub struct AttestArtifacts {
     pub certs: Vec<Certificate>,
     pub log: dice_verifier::Log,
     pub attestation: dice_verifier::Attestation,
-    pub fixed_corpus: Vec<Utf8PathBuf>,
+    pub test_corpus: Vec<Utf8PathBuf>,
 }
 
 /// This function encapsulates our IPCC usage in a non-async function. This is
@@ -399,17 +401,17 @@ pub fn get_attest_data(
     use dice_verifier::{ipcc::AttestIpcc, Attest, AttestMock};
 
     // create the `Attest` impl prescribed by the config
-    let (attest, fixed_corpus): (Box<dyn Attest>, Vec<Utf8PathBuf>) =
+    let (attest, test_corpus): (Box<dyn Attest>, Vec<Utf8PathBuf>) =
         match config {
             AttestConfig::Ipcc => (Box::new(AttestIpcc::new()?), vec![]),
             AttestConfig::Local {
                 priv_key,
                 cert_chain,
                 log,
-                fixed_corpus,
+                test_corpus,
             } => (
                 Box::new(AttestMock::load(cert_chain, log, priv_key)?),
-                fixed_corpus.to_vec(),
+                test_corpus.to_vec(),
             ),
         };
 
@@ -417,6 +419,6 @@ pub fn get_attest_data(
         certs: attest.get_certificates()?,
         log: attest.get_measurement_log()?,
         attestation: attest.attest(nonce)?,
-        fixed_corpus,
+        test_corpus,
     })
 }

--- a/tls/src/lib.rs
+++ b/tls/src/lib.rs
@@ -357,7 +357,7 @@ mod tests {
                 priv_key: attest_priv_key,
                 cert_chain: attest_cert_chain,
                 log: pki_keydir.join("log.bin"),
-                fixed_corpus: vec![],
+                test_corpus: vec![],
             },
             roots: vec![pki_keydir.join("test-root-a.cert.pem")],
             resolve: keys::ResolveSetting::Local {

--- a/tls/src/lib.rs
+++ b/tls/src/lib.rs
@@ -357,6 +357,7 @@ mod tests {
                 priv_key: attest_priv_key,
                 cert_chain: attest_cert_chain,
                 log: pki_keydir.join("log.bin"),
+                fixed_corpus: vec![],
             },
             roots: vec![pki_keydir.join("test-root-a.cert.pem")],
             resolve: keys::ResolveSetting::Local {

--- a/tls/src/server.rs
+++ b/tls/src/server.rs
@@ -244,7 +244,7 @@ impl SprocketsAcceptor {
         )?;
         info!(log, "Peer attestation verified");
 
-        for c in attest_data.fixed_corpus {
+        for c in attest_data.test_corpus {
             corims.push(Corim::from_file(c)?);
         }
 

--- a/tls/src/server.rs
+++ b/tls/src/server.rs
@@ -113,7 +113,6 @@ impl SprocketsAcceptor {
         for c in corpus {
             corims.push(Corim::from_file(c)?);
         }
-        let corpus = ReferenceMeasurements::try_from(corims.as_slice())?;
 
         let mut stream = tls_acceptor.clone().accept(stream).await?;
 
@@ -245,6 +244,11 @@ impl SprocketsAcceptor {
         )?;
         info!(log, "Peer attestation verified");
 
+        for c in attest_data.fixed_corpus {
+            corims.push(Corim::from_file(c)?);
+        }
+
+        let corpus = ReferenceMeasurements::try_from(corims.as_slice())?;
         // appraise measurements from client attestation against reference
         // measurements
         let measurements =


### PR DESCRIPTION
For testing purposes it's really useful to be able to pass in a fixed reference corpus as part of a config for local measurements.