### PR TITLE
Fix latent clippy lints surfaced by --all-targets on illumos

### DIFF
--- a/tls/build.rs
+++ b/tls/build.rs
@@ -24,9 +24,9 @@ where
 {
     let mock = R::load(input)?;
     let log = mock.to_bytes()?;
-    Ok(std::fs::write(output, &log).with_context(|| {
-        format!("write mock measurement log to file: {}", output)
-    })?)
+    std::fs::write(output, &log).with_context(|| {
+        format!("write mock measurement log to file: {output}")
+    })
 }
 
 /// Execute one of the `attest-mock` commands to generate attestation
@@ -34,8 +34,8 @@ where
 fn main() -> Result<()> {
     #[cfg(target_os = "illumos")]
     {
-        println!("cargo:rustc-link-arg=-Wl,-R{}", OXIDE_PLATFORM);
-        println!("cargo:rustc-link-search={}", OXIDE_PLATFORM);
+        println!("cargo:rustc-link-arg=-Wl,-R{OXIDE_PLATFORM}");
+        println!("cargo:rustc-link-search={OXIDE_PLATFORM}");
     }
 
     #[cfg(feature = "unittest")]
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
         let config_path = "test-keys/config.kdl";
         let doc =
             config::load_and_validate(config_path.as_ref()).map_err(|e| {
-                anyhow!("Loading config from \"{}\" failed: {e:?}", config_path)
+                anyhow!("Loading config from \"{config_path}\" failed: {e:?}")
             })?;
 
         doc.write_key_pairs(outdir.clone(), OutputFileExistsBehavior::Skip)

--- a/tls/examples/client.rs
+++ b/tls/examples/client.rs
@@ -60,7 +60,7 @@ async fn main() {
 
     let args = Args::parse();
 
-    if args.roots.len() < 1 {
+    if args.roots.is_empty() {
         panic!("Need at least one root");
     }
 

--- a/tls/examples/server.rs
+++ b/tls/examples/server.rs
@@ -59,7 +59,7 @@ async fn main() {
 
     let args = Args::parse();
 
-    if args.roots.len() < 1 {
+    if args.roots.is_empty() {
         panic!("Must specify at least one root");
     }
 


### PR DESCRIPTION
**_CAVEAT LECTOR:_ This PR was generated by Claude Fable 5.**

`cargo clippy --all-targets -- -D warnings` fails on illumos — where the `cfg(target_os = "illumos")` build-script lines and the `unittest` build path actually compile — on lints the ubuntu CI run never sees:

- uninlined format args in `build.rs` (the `OXIDE_PLATFORM` link lines, and the mock-log message introduced in #106's build-script rework) and a `needless_question_mark` `Ok(..?)` wrapper around `fs::write`
- `args.roots.len() < 1` instead of `is_empty()` in both examples

Pure lint fixes; no behavior change.

Verified on illumos: `cargo clippy --all-targets -- -D warnings` clean, `cargo test` 6/6.

## Relationships

Independent of #107 and #108; the three can land in any order.