### PR TITLE
Change the format of fake PlatformIds

### DIFF
--- a/tls/test-keys/config.kdl
+++ b/tls/test-keys/config.kdl
@@ -85,7 +85,7 @@ key-pair "test-platformid-1" {
 entity "test-platformid-1" {
     country-name "US"
     organization-name "Oxide Computer Company"
-    common-name "PDV2:913-0000019:RRR:20000001"
+    common-name "PDV2:913-0000019:RRR:2FAKE001"
 }
 
 certificate "test-platformid-1" {
@@ -261,7 +261,7 @@ key-pair "test-platformid-2" {
 entity "test-platformid-2" {
     country-name "US"
     organization-name "Oxide Computer Company"
-    common-name "PDV2:913-0000019:RRR:20000002"
+    common-name "PDV2:913-0000019:RRR:2FAKE002"
 }
 
 certificate "test-platformid-2" {

--- a/tls/test-utils/src/lib.rs
+++ b/tls/test-utils/src/lib.rs
@@ -520,7 +520,7 @@ pub fn generate_config_start_end(start: usize, end: usize) -> ValidDocument {
 /// Return the platform id string associated with the `nth` sprockets
 /// configuration
 pub fn platform_id(n: usize) -> String {
-    format!("PDV2:913-0000019:RRR:2{n:07}")
+    format!("PDV2:913-0000019:RRR:2FAKE{n:03}")
 }
 
 pub fn platform_id_prefix(n: usize) -> String {


### PR DESCRIPTION
This makes explicit what the serials mean.

Once this changes, there will need to be updates made to a4x2, voxel, and Omicron.